### PR TITLE
Remove PHP 8.2 deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mergado API Client for PHP
 
 ## Requirements:
-**PHP**: 7.2 || 7.4 || 8.0 || 8.1
+**PHP**: 7.2 || 7.4 || 8.0 || 8.1 || 8.2
 
 ## Instalation:
 `composer require mergado/mergado-api-client`

--- a/src/mergadoclient/OAuth2/MergadoProvider.php
+++ b/src/mergadoclient/OAuth2/MergadoProvider.php
@@ -16,14 +16,11 @@ class MergadoProvider extends AbstractProvider {
 	 */
 	const DEFAULT_BASE_URL = 'https://app.mergado.com/oauth2';
 
+    protected $oAuthEndpoint;
+
 	public function __construct(array $options = [], array $collaborators = []) {
 
 		$this->assertRequiredOptions($options);
-
-		foreach ($options as $key => $value) {
-			$this->$key = $value;
-		}
-
 		parent::__construct($options, $collaborators);
 
 	}


### PR DESCRIPTION
This PR aims to remove dynamic properties from MergadoProvider.
This feature was deprecated in PHP 8.2 and triggers a warning.